### PR TITLE
Fix typo in package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ language objects sorted by quality.
 
 ## Installation
 
-`npm install @escpace/accept-language-parser`
+`npm install @escapace/accept-language-parser`
 
 ## API
 


### PR DESCRIPTION
This PR fixes the typo in the package name: `@escpace/...` → `@escapace/...`